### PR TITLE
Fixes blocking of query requests when player with name "null" joins

### DIFF
--- a/src/main/java/org/itxtech/nemisys/Player.java
+++ b/src/main/java/org/itxtech/nemisys/Player.java
@@ -82,6 +82,10 @@ public class Player {
                 this.skin = loginPacket.skin;
                 this.name = loginPacket.username;
                 this.uuid = loginPacket.clientUUID;
+                if (this.uuid == null) {
+                    this.close(TextFormat.RED + "Please choose another name and try again!");
+                    break;
+                }
                 this.rawUUID = Binary.writeUUID(this.uuid);
                 this.randomClientId = loginPacket.clientId;
                 this.protocol = loginPacket.protocol;


### PR DESCRIPTION
When a player with the name "null" is joining the server then this will cause a java.lang.NullPointerException.
After it the query server fails for new queries and block incoming requests for 300 seconds. In this time the server seems dead/offline, but is currently running.
With this fix those players are kicked at login. Maybe you can solve it in a more elegand way. ;-)

[Fixes #54 and probably #49 and maybe even #38]
