### PR TITLE
Changes error message for blocked 0.16 players (UUID==null)

### DIFF
--- a/src/main/java/org/itxtech/nemisys/Player.java
+++ b/src/main/java/org/itxtech/nemisys/Player.java
@@ -83,7 +83,7 @@ public class Player {
                 this.name = loginPacket.username;
                 this.uuid = loginPacket.clientUUID;
                 if (this.uuid == null) {
-                    this.close(TextFormat.RED + "Please choose another name and try again!");
+                    this.close(TextFormat.RED + "Sorry, your version of MCPE is currently not supported by this server!");
                     break;
                 }
                 this.rawUUID = Binary.writeUUID(this.uuid);


### PR DESCRIPTION
The issue which leads to a player name "null" was caused by MCPE versions 0.15.90 and above. So the old message "_Please choose another name and try again!_" was not very helpful and is now replaced.
