### PR TITLE
Updated wrong version's number on Nemisys.java

### DIFF
--- a/src/main/java/org/itxtech/nemisys/Nemisys.java
+++ b/src/main/java/org/itxtech/nemisys/Nemisys.java
@@ -9,8 +9,8 @@ public class Nemisys {
     public final static String VERSION = "1.0dev";
     public final static String API_VERSION = "1.0.6";//majorVersion.minorVersion.sppVersion
     public final static String CODENAME = "Aegis";
-    public final static String MINECRAFT_VERSION = "v0.16.1 alpha";
-    public final static String MINECRAFT_VERSION_NETWORK = "0.16.1";
+    public final static String MINECRAFT_VERSION = "v1.0.0 alpha";
+    public final static String MINECRAFT_VERSION_NETWORK = "1.0.0";
 
     public final static String PATH = System.getProperty("user.dir") + "/";
     public final static String DATA_PATH = System.getProperty("user.dir") + "/";


### PR DESCRIPTION
It was perturbing me. (lol)
PS: Can I delete the "alpha"'s word on MINECRAFT_VERSION ? MC:PE is no longer in alpha.